### PR TITLE
Added feature: configuration options to allow hiding each menu item

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ out
 node_modules
 assets
 .vscode-test/**
+*.vsix

--- a/package.json
+++ b/package.json
@@ -42,8 +42,58 @@
     ],
     "main": "./out/src/extension",
     "contributes": {
-        "commands": [
-            {
+        "configuration": {
+            "type": "object",
+            "title": "Angular Files menu option configuration",
+            "properties": {
+                "angular2-files.menu.component": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Shows or hides the menu item."
+                },
+                "angular2-files.menu.directive": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Shows or hides the menu item."
+                },
+                "angular2-files.menu.pipe": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Shows or hides the menu item."
+                },
+                "angular2-files.menu.service": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Shows or hides the menu item."
+                },
+                "angular2-files.menu.class": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Shows or hides the menu item."
+                },
+                "angular2-files.menu.interface": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Shows or hides the menu item."
+                },
+                "angular2-files.menu.route": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Shows or hides the menu item."
+                },
+                "angular2-files.menu.enum": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Shows or hides the menu item."
+                },
+                "angular2-files.menu.module": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Shows or hides the menu item."
+                }
+            }
+        },
+        "commands": [{
                 "command": "extension.addAngular2Component",
                 "title": "Generate Component"
             },
@@ -81,49 +131,48 @@
             }
         ],
         "menus": {
-            "explorer/context": [
-                {
-                    "when": "",
+            "explorer/context": [{
+                    "when": "config.angular2-files.menu.component",
                     "command": "extension.addAngular2Component",
                     "group": "Angular2"
                 },
                 {
-                    "when": "",
+                    "when": "config.angular2-files.menu.directive",
                     "command": "extension.addAngular2Directive",
                     "group": "Angular2"
                 },
                 {
-                    "when": "",
+                    "when": "config.angular2-files.menu.pipe",
                     "command": "extension.addAngular2Pipe",
                     "group": "Angular2"
                 },
                 {
-                    "when": "",
+                    "when": "config.angular2-files.menu.service",
                     "command": "extension.addAngular2Service",
                     "group": "Angular2"
                 },
                 {
-                    "when": "",
+                    "when": "config.angular2-files.menu.module",
                     "command": "extension.addAngular2Module",
                     "group": "Angular2"
                 },
                 {
-                    "when": "",
+                    "when": "config.angular2-files.menu.class",
                     "command": "extension.addAngular2Class",
                     "group": "Angular2 Essentials"
                 },
                 {
-                    "when": "",
+                    "when": "config.angular2-files.menu.interface",
                     "command": "extension.addAngular2Interface",
                     "group": "Angular2 Essentials"
                 },
                 {
-                    "when": "",
+                    "when": "config.angular2-files.menu.route",
                     "command": "extension.addAngular2Route",
                     "group": "Angular2 Essentials"
                 },
                 {
-                    "when": "",
+                    "when": "config.angular2-files.menu.enum",
                     "command": "extension.addAngular2Enum",
                     "group": "Angular2 Essentials"
                 }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -3,13 +3,13 @@ import { ICommand } from './models/command';
 import { CommandType } from './enums/command-type';
 
 export const commandsMap = new Map<CommandType, ICommand>([
-  [CommandType.Component, { fileName: 'my-component.component.ts', resource: ResourceType.Component }],
-  [CommandType.Directive, { fileName: 'my-directive.directive.ts', resource: ResourceType.Directive }],
-  [CommandType.Pipe, { fileName: 'my-pipe.pipe.ts', resource: ResourceType.Pipe }],
-  [CommandType.Service, { fileName: 'my-service.service.ts', resource: ResourceType.Service }],
-  [CommandType.Class, { fileName: 'my-class.class.ts', resource: ResourceType.Class }],
-  [CommandType.Interface, { fileName: 'my-interface.interface.ts', resource: ResourceType.Interface }],
-  [CommandType.Route, { fileName: 'my-route.routing.ts', resource: ResourceType.Route }],
-  [CommandType.Enum, { fileName: 'my-enum.enum.ts', resource: ResourceType.Enum }],
-  [CommandType.Module, { fileName: 'my-module.module.ts', resource: ResourceType.Module }],
+  [CommandType.Component, { fileName: 'my-component', resource: ResourceType.Component }],
+  [CommandType.Directive, { fileName: 'my-directive', resource: ResourceType.Directive }],
+  [CommandType.Pipe, { fileName: 'my-pipe', resource: ResourceType.Pipe }],
+  [CommandType.Service, { fileName: 'my-service', resource: ResourceType.Service }],
+  [CommandType.Class, { fileName: 'my-class', resource: ResourceType.Class }],
+  [CommandType.Interface, { fileName: 'my-interface', resource: ResourceType.Interface }],
+  [CommandType.Route, { fileName: 'my-route', resource: ResourceType.Route }],
+  [CommandType.Enum, { fileName: 'my-enum', resource: ResourceType.Enum }],
+  [CommandType.Module, { fileName: 'my-module', resource: ResourceType.Module }],
 ]);


### PR DESCRIPTION
Please consider this pull-request...

I removed the ".type.ts" extension from the "fileName" field of the commands to prevent confusion when presented with the input prompt for a name. Initially upon using this extensions it was unclear it was expecting only the name portion and I wound up with a directory called "my-name.coponent.ts" with subsequent files name things like "my-name.coponent.ts.coponent.ts".

I've also add configuration options that enable end-users to hide specific menu options they don't want to see... The configuration options as follows:
```javascript
{
  "angular2-files.menu.class": false,
  "angular2-files.menu.component": true,
  "angular2-files.menu.directive": true,
  "angular2-files.menu.enum": false,
  "angular2-files.menu.interface": false,
  "angular2-files.menu.module": false,
  "angular2-files.menu.pipe": true,
  "angular2-files.menu.route": false,
  "angular2-files.menu.service": true
}
```

Lastly I added the *.vsix extension to .gitignore.

Thanks for the extension, it's a great time-saver!