### PR TITLE
Add support for simple resolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Shows or hides the menu item."
+                },
+                "angular2-files.menu.resolver": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Shows or hides the menu item."
                 }
             }
         },
@@ -129,6 +134,10 @@
             {
                 "command": "extension.addAngular2Module",
                 "title": "Generate Module"
+            },
+            {
+                "command": "extension.addAngular2Resolver",
+                "title": "Generate Resolver"
             }
         ],
         "menus": {
@@ -176,6 +185,11 @@
                 {
                     "when": "config.angular2-files.menu.enum",
                     "command": "extension.addAngular2Enum",
+                    "group": "Angular2 Essentials"
+                },
+                {
+                    "when": "config.angular2-files.menu.resolver",
+                    "command": "extension.addAngular2Resolver",
                     "group": "Angular2 Essentials"
                 }
             ]

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -7,6 +7,7 @@ export const commandsMap = new Map<CommandType, ICommand>([
   [CommandType.Directive, { fileName: 'my-directive', resource: ResourceType.Directive }],
   [CommandType.Pipe, { fileName: 'my-pipe', resource: ResourceType.Pipe }],
   [CommandType.Service, { fileName: 'my-service', resource: ResourceType.Service }],
+  [CommandType.Resolver, { fileName: 'my-resolver', resource: ResourceType.Resolver }],
   [CommandType.Class, { fileName: 'my-class', resource: ResourceType.Class }],
   [CommandType.Interface, { fileName: 'my-interface', resource: ResourceType.Interface }],
   [CommandType.Route, { fileName: 'my-route', resource: ResourceType.Route }],

--- a/src/config/cli-config.ts
+++ b/src/config/cli-config.ts
@@ -53,5 +53,9 @@ export const config: IConfig = {
       flat: true,
       spec: true,
     },
+    resolver: {
+      flat: true,
+      spec: false,
+    },
   },
 };

--- a/src/enums/command-type.ts
+++ b/src/enums/command-type.ts
@@ -8,4 +8,5 @@ export enum CommandType {
     Enum = 'extension.addAngular2Enum',
     Interface = 'extension.addAngular2Interface',
     Route = 'extension.addAngular2Route',
+    Resolver = "extension.addAngular2Resolver"
 }

--- a/src/enums/resource-type.ts
+++ b/src/enums/resource-type.ts
@@ -9,4 +9,5 @@ export enum ResourceType {
     Interface = 'interface',
     Route = 'route',
     Guard = 'guard',
+    Resolver = 'resolver',
 }

--- a/src/enums/template-type.ts
+++ b/src/enums/template-type.ts
@@ -17,4 +17,5 @@ export enum TemplateType {
     Enum = 'enum.tmpl',
     Inteface = 'interface.tmpl',
     Route = 'route.tmpl',
+    Resolver = 'resolver.tmpl'
 }

--- a/src/models/config-new.ts
+++ b/src/models/config-new.ts
@@ -73,4 +73,9 @@ export interface SchematicOptions {
   [k: string]: {
     [k: string]: any;
   };
+  '@schematics/angular:resolver'?: {
+    flat?: boolean;
+    spec?: boolean;
+    [k: string]: any;
+  };
 }

--- a/src/models/config.ts
+++ b/src/models/config.ts
@@ -52,6 +52,7 @@ export interface IDefaults {
   module?: IProperties;
   pipe?: IProperties;
   service?: IProperties;
+  resolver?: IProperties;
 }
 
 export interface IConfig {

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -44,6 +44,16 @@ export const resources = new Map<ResourceType, IResource>([
     options: [OptionType.Flat,
       OptionType.Spec],
   }],
+  [ResourceType.Resolver, {
+    locDirName: (loc, config) => (!config.defaults.resolver.flat) ? loc.fileName : loc.dirName,
+    locDirPath: (loc, config) => path.join(loc.dirPath, loc.dirName),
+    files: [
+      { name: config => `resolver.ts`, type: TemplateType.Resolver, condition: (config, params) => config.version === 'ng6' },
+    ],
+    createFolder: config => !config.defaults.resolver.flat,
+    options: [OptionType.Flat,
+      OptionType.Spec],
+  }],
   [ResourceType.Pipe, {
     locDirName: (loc, config) => (!config.defaults.pipe.flat) ? loc.fileName : loc.dirName,
     locDirPath: (loc, config) => path.join(loc.dirPath, loc.dirName),

--- a/templates/resolver.tmpl
+++ b/templates/resolver.tmpl
@@ -1,0 +1,11 @@
+import { Injectable } from '@angular/core';
+import { Resolve, Router } from '@angular/router';
+
+@Injectable()
+export class ${upperName}Resolver implements Resolve<T> {
+
+constructor(private router: Router) { }
+
+resolve() { }
+
+}


### PR DESCRIPTION
First time I've ever touched vs code extension code before, so not sure if this works as I've not successfully tested it. Tried to click the 'Generate Resolver' option in the menu, but the naming popup didn't show. Not sure what steps needs to be taken to be able to test it properly. 

Anyway, I wanted to create an option to generate a simple resolver. This should also resolve #41.

Feedback and/or guidelines is very much appreciated 😄 